### PR TITLE
Add pnpm install step before running tests in CI pipeline

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           version: 9
 
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run all tests
         run: pnpm run test
 


### PR DESCRIPTION
This PR adds the pnpm install step before running the tests in the CI pipeline to ensure that all necessary dependencies are installed before executing the tests.