### PR TITLE
Fix: Make Docker container accessible on all network interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.dev
     env_file:
       - .env
-    command: pnpm run dev
+    command: pnpm run dev --ip 0.0.0.0
     tty: true
     ports:
       - "3000:3000"


### PR DESCRIPTION
This PR updates the `docker-compose.yml` file to include the `--ip 0.0.0.0` command in the container configuration. 